### PR TITLE
ci: migrate nix-dependent workflows to self-hosted runners

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     name: Merge automatic pull requests
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 12
     permissions:
       actions: write
@@ -31,8 +31,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Start the tests
         run: |
           gh api \
@@ -73,7 +71,7 @@ jobs:
   flake:
     name: Freeze the latest lockfile
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       actions: write
       contents: write
@@ -87,8 +85,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Checkout an update
         run: |
           git checkout -b update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Maps the right tested files
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:
@@ -17,7 +17,5 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Run tests
         run: nix develop -c make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ to [Semantic Versioning][semver].
 - Replace handle with name of authorship at time of publication in licenses.
 
 ### Maintenance
-- Migrate nix dependent workflows to use self hosted runner machines.
 
 - Require changes to the changelog before merging changes after development.
 - Include the packaged plugin as part of the flake package derivation output.
@@ -22,6 +21,7 @@ to [Semantic Versioning][semver].
 - Start tests on a whim with a workflow dispatch option with testing events.
 - Automate incrementations of the open source license to keep things current.
 - Overwrite failed attempts to update dependencies after waiting some times.
+- Prefer self hosted runners for nix package installation within a workflow.
 
 ## [0.1.1] - 2024-12-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning][semver].
 - Replace handle with name of authorship at time of publication in licenses.
 
 ### Maintenance
+- Migrate nix dependent workflows to use self hosted runner machines.
 
 - Require changes to the changelog before merging changes after development.
 - Include the packaged plugin as part of the flake package derivation output.


### PR DESCRIPTION
Switches nix-dependent jobs to self-hosted runners and removes the DeterminateSystems nix-installer-action setup step. Changelog check stays on ubuntu-latest since it doesn't need nix.