### PR TITLE
ci: test updates inline to avoid overhead of multiple pending runner at once

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -33,24 +33,7 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - name: Start the tests
         run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$REPO/actions/workflows/tests.yml/dispatches" \
-             -f "ref=$REF"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REF: ${{ github.head_ref }}
-          REPO: ${{ github.repository }}
-      - name: Wait for tests to succeed
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
-        with:
-          allowed-conclusions: success
-          check-name: "Maps the right tested files"
-          ref: ${{ github.head_ref }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
+          nix develop -c make test
       - name: Merge requests from the kind dependabot
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"
@@ -111,24 +94,7 @@ jobs:
       - name: Start the tests
         if: steps.diff.outputs.changed == 'true'
         run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$REPO/actions/workflows/tests.yml/dispatches" \
-             -f "ref=update"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-      - name: Wait for tests to succeed
-        if: steps.diff.outputs.changed == 'true'
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
-        with:
-          allowed-conclusions: success
-          check-name: "Maps the right tested files"
-          ref: update
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
+          nix develop -c make test
       - name: Save changed version
         if: steps.diff.outputs.changed == 'true'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ to [Semantic Versioning][semver].
 
 ### Maintenance
 
+- Test dependency updates inline to avoid overhead of multiple pending runner at once.
 - Require changes to the changelog before merging changes after development.
 - Include the packaged plugin as part of the flake package derivation output.
 - Remove flake utilities from build inputs for a more minimal configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ to [Semantic Versioning][semver].
 
 ### Maintenance
 
-- Test dependency updates inline to avoid overhead of multiple pending runner at once.
 - Require changes to the changelog before merging changes after development.
 - Include the packaged plugin as part of the flake package derivation output.
 - Remove flake utilities from build inputs for a more minimal configuration.
@@ -23,6 +22,7 @@ to [Semantic Versioning][semver].
 - Automate incrementations of the open source license to keep things current.
 - Overwrite failed attempts to update dependencies after waiting some times.
 - Prefer self hosted runners for nix package installation within a workflow.
+- Test updates to dependencies inline to avoid overhead of multiple runners.
 
 ## [0.1.1] - 2024-12-29
 


### PR DESCRIPTION
The `lewagon/wait-on-check-action` composite action uses `ruby/setup-ruby` internally, which fails on the self-hosted NixOS runner.

This replaces the dependency workflow's dispatch-and-wait pattern with direct inline execution, so dependency update validation happens in the same workflow instead of spawning extra pending runs.